### PR TITLE
Add exploratory test to check how Retrofit handles 404 case

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson")
     implementation("com.squareup.retrofit2:adapter-rxjava2")
     implementation("com.google.code.gson:gson")
+    implementation("com.squareup.okhttp3:mockwebserver")
 
     implementation("io.reactivex.rxjava2:rxjava")
     implementation("io.reactivex.rxjava2:rxandroid")

--- a/app/src/main/kotlin/com/olderwold/sliide/data/GoRestClient.kt
+++ b/app/src/main/kotlin/com/olderwold/sliide/data/GoRestClient.kt
@@ -42,7 +42,10 @@ internal interface GoRestClient {
 
     companion object {
         @SuppressLint("NewApi")
-        operator fun invoke(clientBuilder: OkHttpClient.Builder.() -> Unit = {}): GoRestClient {
+        operator fun invoke(
+            retrofitBuilder: Retrofit.Builder.() -> Unit = {},
+            clientBuilder: OkHttpClient.Builder.() -> Unit = {}
+        ): GoRestClient {
             val gson = GsonFactory().create()
 
             val api = Retrofit.Builder()
@@ -55,6 +58,7 @@ internal interface GoRestClient {
                         .apply(clientBuilder)
                         .build()
                 )
+                .apply(retrofitBuilder)
                 .build()
                 .create(Api::class.java)
 

--- a/app/src/test/kotlin/com/olderwold/sliide/data/GoRestClientMockTest.kt
+++ b/app/src/test/kotlin/com/olderwold/sliide/data/GoRestClientMockTest.kt
@@ -1,0 +1,33 @@
+@file:Suppress("DEPRECATION")
+
+package com.olderwold.sliide.data
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.adapter.rxjava2.HttpException
+
+class GoRestClientMockTest {
+    @get:Rule
+    val server = MockWebServer()
+
+    @Test
+    fun `retrofit call adapter should rethrow 404 as HttpException`() {
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        val api = GoRestClient(retrofitBuilder = {
+            baseUrl(server.url("."))
+        })
+
+        api.users(page = 10).test()
+            .assertError { throwable ->
+                with(throwable as HttpException) {
+                    code() shouldBeEqualTo 404
+                    message() shouldBeEqualTo "Client Error"
+                }
+                true
+            }
+    }
+}

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
         val okhttpVersion = "4.4.1"
         api("com.squareup.okhttp3:okhttp:$okhttpVersion")
         api("com.squareup.okhttp3:logging-interceptor:$okhttpVersion")
+        api("com.squareup.okhttp3:mockwebserver:$okhttpVersion")
 
         val retrofitVersion = "2.9.0"
         api("com.squareup.retrofit2:retrofit:$retrofitVersion")


### PR DESCRIPTION
# What is done?
* Added `mockwebserver`
* Implemented test that yields 404 case

# Motivation
* Explore the return types and state of the stream when 404 encountered